### PR TITLE
Add stripslashes to ajax call for shortcode

### DIFF
--- a/lib/includes/class-ajax.php
+++ b/lib/includes/class-ajax.php
@@ -146,7 +146,7 @@ class AJAX {
 
 				if ( ! empty( $_POST[ '_cpb_content_' . $id ] ) ) {
 
-					$content = wp_kses_post( $_POST[ '_cpb_content_' . $id ] );
+					$content = wp_kses_post( stripslashes( $_POST[ '_cpb_content_' . $id ] ) );
 
 				} else {
 

--- a/plugin.php
+++ b/plugin.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: CAHNRS WSUWP Pagebuilder 3.0
-Version: 3.0.7
+Version: 3.0.8
 Description: Builds customizable page layouts
 Author: washingtonstateuniversity, cahnrscommunications, Danial Bleile
 Author URI: http://cahnrs.wsu.edu/communications


### PR DESCRIPTION
The ajax call returning shortcode content in the admin was being returned with escaping backslashes in the quotation marks. This was resulting in shortcodes being essentially called and rendered with no parameters when previewing in the backend.